### PR TITLE
Bump commons-io from 1.3.2 to 2.7 in /bw6-maven-plugin

### DIFF
--- a/bw6-maven-plugin/pom.xml
+++ b/bw6-maven-plugin/pom.xml
@@ -69,7 +69,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>1.3.2</version>
+			<version>2.7</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Bumps commons-io from 1.3.2 to 2.7.

Signed-off-by: dependabot[bot] <support@github.com>